### PR TITLE
Documentation improvement 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ behavior of the parser via Common Lisp restarts.
 
 Inspired by Haskell's `optparse-applicative` and Python's `argparse`.
 
+It is portable accross many implementations (10 and counting).
+
 ## Installation
 
 Copy files of this library in any place where ASDF can find them. Then you
@@ -23,6 +25,9 @@ Via Quicklisp (recommended):
 ```common-lisp
 (ql:quickload "unix-opts")
 ```
+
+Now you can use its shorter nickname `opts`.
+
 
 ## Description
 
@@ -194,6 +199,24 @@ sexy! Basically, we have defined all the options just like this:
    :arg-parser #'identity
    :meta-var "FILE"))
 ```
+
+and we read them like so:
+
+```
+(opts:get-opts)
+```
+
+which returns two values, a list of parsed options and the remaining
+arguments:
+
+```
+(multiple-value-bind (options free-args)
+    (opts:get-opts)
+  (if (getf options :verbose)
+      ...
+```
+
+See the example for helpers and how to handle malformed or incomplete arguments.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ behavior of the parser via Common Lisp restarts.
 
 Inspired by Haskell's `optparse-applicative` and Python's `argparse`.
 
-It is portable accross many implementations (10 and counting).
+It is portable accross implementations (reads `sb-ext:*posix-argv*`
+for SBCL, etc).
 
 ## Installation
 
@@ -26,17 +27,17 @@ Via Quicklisp (recommended):
 (ql:quickload "unix-opts")
 ```
 
-Now you can use its shorter nickname `opts`.
+Now you can also use its shorter nickname `opts`.
 
 
-## Description
+## Functions
 
 ```
 option condition
 ```
 
-Take a condition `condition` (`unknown-option`, `missing-arg`, or
-`arg-parser-failed`) and return string representing option in question.
+Takes a condition `condition` (`unknown-option`, `missing-arg`, or
+`arg-parser-failed`) and returns a string representing the option in question.
 
 ----
 
@@ -44,7 +45,7 @@ Take a condition `condition` (`unknown-option`, `missing-arg`, or
 raw-arg condition
 ```
 
-Take a condition of type `arg-parser-failed` and return raw argument string.
+Takes a condition of type `arg-parser-failed` and returns the raw argument string.
 
 ----
 
@@ -79,8 +80,8 @@ printed in option description.
 argv
 ```
 
-Return list of program's arguments, including command used to execute the
-program as first elements of the list.
+Returns a list of the program's arguments, including the command used to execute the
+program as the first element of the list.  Portable accross implementations.
 
 ----
 
@@ -88,29 +89,49 @@ program as first elements of the list.
 get-opts &optional options
 ```
 
-Parse command line options. If `options` is given, it should be a list to
-parse. If it's not given, the function will use the `argv` function to get
-list of command line arguments. Return two values: list that contains
-keywords associated with command line options with `define-opts` macro, and
-list of free arguments. If some option requires an argument, you can use
-`getf` to test presence of the option and get its argument if the option is
-present.
+Parses command line options. If `options` is given, it should be a list to
+parse. If it's not given, the function will use the `argv` function to get the
+list of command line arguments.
+
+Returns two values:
+- a list that contains keywords associated with command line options
+  with `define-opts` macro, and
+- a list of free arguments.
+
+If some option requires an argument, you can use `getf` to test the
+presence of the option and get its argument if the option is present.
+
+```
+describe &key prefix suffix usage-of args stream
+```
+
+Return a string describing all the options of the program that were defined with
+the previous `define-opts` macro. You can supply `prefix` and `suffix`
+arguments that will be printed before and after the options respectively. If
+`usage-of` is supplied, it should be a string, the name of the program for an
+"Usage: " section. This section is only printed if this name is given. If
+your program takes arguments (apart from options), you can specify how to
+print them in "Usage: " section with an `args` option (should be a string
+designator). Output goes to `stream` (default value is `*standard-output*`).
+
+Handling malformed options
+--------------------------
 
 The parser may signal various conditions. Let's list them all specifying
 which restarts are available for every condition, and what kind of
 information the programmer can extract from the conditions.
 
-`unknown-option` is thrown when parser encounters unknown (not previously
-defined with `define-opts`) option. Use the `option` reader to get name of
+- `unknown-option` is thrown when the parser encounters an unknown (not previously
+defined with `define-opts`) option. Use the `option` reader to get the name of
 the option (string). Available restarts: `use-value` (substitute the option
 and try again), `skip-option` (ignore the option).
 
-`missing-arg` is thrown when some option wants an argument, but there is no
-such argument given. Use the `option` reader to get name of the option
+- `missing-arg` is thrown when some option wants an argument, but there is no
+such argument given. Use the `option` reader to get the name of the option
 (string). Available restarts: `use-value` (supplied value will be used),
 `skip-option` (ignore the option).
 
-`arg-parser-failed` is thrown when some option wants an argument, it's given
+- `arg-parser-failed` is thrown when some option wants an argument, it's given
 but cannot be parsed by argument parser. Use the `option` reader to get name
 of the option (string) and `raw-arg` to get raw string representing the
 argument before parsing. Available restarts: `use-value` (supplied value
@@ -119,59 +140,12 @@ string will be parsed instead).
 
 ----
 
-```
-describe &key prefix suffix usage-of args stream
-```
-
-Return string describing options of the program that were defined with
-`define-opts` macro previously. You can supply `prefix` and `suffix`
-arguments that will be printed before and after options respectively. If
-`usage-of` is supplied, it should be a string, name of the program for
-"Usage: " section. This section is only printed if this name is given. If
-your program takes arguments (apart from options), you can specify how to
-print them in "Usage: " section with `args` option (should be a string
-designator). Output goes to `stream` (default value is `*standard-output*`).
-
 ## Example
 
-Go to `example` directory. Now, you can use `example.lisp` file to see if
+Go to the `example` directory. Now, you can use `example.lisp` file to see if
 `unix-opts` is cool enough for you to use. SBCL users can use `example.sh`
-file. Here is some tests:
+file.
 
-```
-$ sh example.sh --help
-example—program to demonstrate unix-opts library
-
-Usage: example.sh [-h|--help] [-v|--verbose] [-l|--level LEVEL]
-                  [-o|--output FILE] [FREE-ARGS]
-
-Available options:
-  -h, --help               print this help text
-  -v, --verbose            verbose output
-  -l, --level LEVEL        the program will run on LEVEL level
-  -o, --output FILE        redirect output to file FILE
-
-so that's how it works…
-free args:
-$ sh example.sh -v file1.txt file2.txt
-OK, running in verbose mode…
-free args: file1.txt, file2.txt
-$ sh example.sh --level 10 --output foo.txt bar.txt
-I see you've supplied level option, you want 10 level!
-I see you want to output the stuff to "foo.txt"!
-free args: bar.txt
-$ sh example.sh --level kitty foo.txt
-fatal: cannot parse "kitty" as argument of "--level"
-free args:
-$ sh example.sh --hoola-boola noola.txt
-warning: "--hoola-boola" option is unknown!
-free args: noola.txt
-$ sh example.sh -vgl=10
-warning: "-g" option is unknown!
-OK, running in verbose mode…
-I see you've supplied level option, you want 10 level!
-free args:
-```
 
 Take a look at `example.lisp` and you will see that the library is pretty
 sexy! Basically, we have defined all the options just like this:
@@ -200,14 +174,8 @@ sexy! Basically, we have defined all the options just like this:
    :meta-var "FILE"))
 ```
 
-and we read them like so:
-
-```
-(opts:get-opts)
-```
-
-which returns two values, a list of parsed options and the remaining
-arguments:
+and we read them with `(opts:get-opts)` which returns two values, a
+list of parsed options and the remaining arguments, so:
 
 ```
 (multiple-value-bind (options free-args)
@@ -218,6 +186,47 @@ arguments:
 
 See the example for helpers and how to handle malformed or incomplete arguments.
 
+Here is an example usage:
+
+```
+$ sh example.sh --help
+example—program to demonstrate unix-opts library
+
+Usage: example.sh [-h|--help] [-v|--verbose] [-l|--level LEVEL]
+                  [-o|--output FILE] [FREE-ARGS]
+
+Available options:
+  -h, --help               print this help text
+  -v, --verbose            verbose output
+  -l, --level LEVEL        the program will run on LEVEL level
+  -o, --output FILE        redirect output to file FILE
+
+so that's how it works…
+free args:
+
+$ sh example.sh -v file1.txt file2.txt
+OK, running in verbose mode…
+free args: file1.txt, file2.txt
+
+$ sh example.sh --level 10 --output foo.txt bar.txt
+I see you've supplied level option, you want 10 level!
+I see you want to output the stuff to "foo.txt"!
+free args: bar.txt
+
+$ sh example.sh --level kitty foo.txt
+fatal: cannot parse "kitty" as argument of "--level"
+free args:
+
+$ sh example.sh --hoola-boola noola.txt
+warning: "--hoola-boola" option is unknown!
+free args: noola.txt
+
+$ sh example.sh -vgl=10
+warning: "-g" option is unknown!
+OK, running in verbose mode…
+I see you've supplied level option, you want 10 level!
+free args:
+```
 ## License
 
 Copyright © 2015–2017 Mark Karpov

--- a/unix-opts.lisp
+++ b/unix-opts.lisp
@@ -162,7 +162,7 @@ printed in option description."
 
 (defun argv ()
   "Return list of program's arguments, including command used to execute the
-program as first elements of the list."
+program as first elements of the list. Portable accross implementations."
   #+abcl      ext:*command-line-argument-list*
   #+allegro   sys:command-line-arguments
   #+:ccl      ccl:*command-line-argument-list*
@@ -235,26 +235,35 @@ program as first elements of the list."
 (defun get-opts (&optional options)
   "Parse command line options. If OPTIONS is given, it should be a list to
 parse. If it's not given, the function will use `argv' function to get list
-of command line arguments. Return two values: list that contains keywords
-associated with command line options with `define-opts' macro, and list of
-free arguments. If some option requires an argument, you can use `getf' to
+of command line arguments.
+
+Return two values:
+- a list that contains keywords
+associated with command line options with `define-opts' macro, and
+- a list of
+free arguments.
+
+If some option requires an argument, you can use `getf' to
 test presence of the option and get its argument if the option is present.
+
+Handling malformed options
+--------------------------
 
 The parser may signal various conditions. Let's list them all specifying
 which restarts are available for every condition, and what kind of
 information the programmer can extract from the conditions.
 
-`unknown-option' is thrown when parser encounters unknown (not previously
+- `unknown-option' is thrown when parser encounters unknown (not previously
 defined with `define-opts') option. Use the `option' reader to get name of
 the option (string). Available restarts: `use-value' (substitute the option
 and try again), `skip-option' (ignore the option).
 
-`missing-arg' is thrown when some option wants an argument, but there is no
+- `missing-arg' is thrown when some option wants an argument, but there is no
 such argument given. Use the `option' reader to get name of the
 option (string). Available restarts: `use-value' (supplied value will be
 used), `skip-option' (ignore the option).
 
-`arg-parser-failed' is thrown when some option wants an argument, it's given
+- `arg-parser-failed' is thrown when some option wants an argument, it's given
 but cannot be parsed by argument parser. Use the `option' reader to get name
 of the option (string) and `raw-arg' to get raw string representing the
 argument before parsing. Available restarts: `use-value' (supplied value


### PR DESCRIPTION
Hello, 

That's a very nice lib, thanks and congrats. The readme wasn't very clear to me, I re-ordered a bit the example (to see the code first, not the shell output), improved the headings, added space, added a bit of code for the example. It still says to go and see the example.lisp. 

And it's portable, and where it actually takes the command line arguments from.

Btw, did you look at CLON ? A short notice about it would be helpful (did you see it, why did you not use it ?).