### PR TITLE
Portable exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ behavior of the parser via Common Lisp restarts.
 
 Inspired by Haskell's `optparse-applicative` and Python's `argparse`.
 
-It is portable accross many implementations (10 and counting).
+It is portable accross implementations.
 
 ## Installation
 
@@ -26,31 +26,25 @@ Via Quicklisp (recommended):
 (ql:quickload "unix-opts")
 ```
 
-Now you can use its shorter nickname `opts`.
+Now you can also use its shorter nickname `opts`.
 
 
-## Description
+## Functions
 
-```
-option condition
-```
+### `(option condition)`
 
-Take a condition `condition` (`unknown-option`, `missing-arg`, or
-`arg-parser-failed`) and return string representing option in question.
+Takes a condition `condition` (`unknown-option`, `missing-arg`, or
+`arg-parser-failed`) and returns a string representing the option in question.
 
 ----
 
-```
-raw-arg condition
-```
+### `(raw-arg condition)`
 
-Take a condition of type `arg-parser-failed` and return raw argument string.
+Takes a condition of type `arg-parser-failed` and returns the raw argument string.
 
 ----
 
-```
-define-opts &rest descriptions
-```
+### (define-opts &rest descriptions)
 
 Define command line options. Arguments of this macro must be plists
 containing various parameters. Here we enumerate all allowed parameters:
@@ -75,42 +69,59 @@ printed in option description.
 
 ----
 
-```
-argv
-```
+### `(argv)`
 
-Return list of program's arguments, including command used to execute the
-program as first elements of the list.
+Returns a list of the program's arguments, including the command used to execute the
+program as the first element of the list.
+
+This function reads your implementation's specific variable (in SBCL,
+`sb-ext:*posix-argv*`, etc).
 
 ----
 
-```
-get-opts &optional options
-```
+### `(get-opts &optional options)`
 
-Parse command line options. If `options` is given, it should be a list to
-parse. If it's not given, the function will use the `argv` function to get
-list of command line arguments. Return two values: list that contains
-keywords associated with command line options with `define-opts` macro, and
-list of free arguments. If some option requires an argument, you can use
-`getf` to test presence of the option and get its argument if the option is
-present.
+Parses command line options. If `options` is given, it should be a list to
+parse. If it's not given, the function will use the `argv` function to get the
+list of command line arguments.
+
+Returns two values:
+- a list that contains keywords associated with command line options
+  with `define-opts` macro, and
+- a list of free arguments.
+
+If some option requires an argument, you can use `getf` to test the
+presence of the option and get its argument if the option is present.
+
+### `(describe &key prefix suffix usage-of args stream)`
+
+Return a string describing all the options of the program that were defined with
+the previous `define-opts` macro. You can supply `prefix` and `suffix`
+arguments that will be printed before and after the options respectively. If
+`usage-of` is supplied, it should be a string, the name of the program for an
+"Usage: " section. This section is only printed if this name is given. If
+your program takes arguments (apart from options), you can specify how to
+print them in "Usage: " section with an `args` option (should be a string
+designator). Output goes to `stream` (default value is `*standard-output*`).
+
+Handling malformed options
+--------------------------
 
 The parser may signal various conditions. Let's list them all specifying
 which restarts are available for every condition, and what kind of
 information the programmer can extract from the conditions.
 
-`unknown-option` is thrown when parser encounters unknown (not previously
-defined with `define-opts`) option. Use the `option` reader to get name of
+- `unknown-option` is thrown when the parser encounters an unknown (not previously
+defined with `define-opts`) option. Use the `option` reader to get the name of
 the option (string). Available restarts: `use-value` (substitute the option
 and try again), `skip-option` (ignore the option).
 
-`missing-arg` is thrown when some option wants an argument, but there is no
-such argument given. Use the `option` reader to get name of the option
+- `missing-arg` is thrown when some option wants an argument, but there is no
+such argument given. Use the `option` reader to get the name of the option
 (string). Available restarts: `use-value` (supplied value will be used),
 `skip-option` (ignore the option).
 
-`arg-parser-failed` is thrown when some option wants an argument, it's given
+- `arg-parser-failed` is thrown when some option wants an argument, it's given
 but cannot be parsed by argument parser. Use the `option` reader to get name
 of the option (string) and `raw-arg` to get raw string representing the
 argument before parsing. Available restarts: `use-value` (supplied value
@@ -119,59 +130,12 @@ string will be parsed instead).
 
 ----
 
-```
-describe &key prefix suffix usage-of args stream
-```
-
-Return string describing options of the program that were defined with
-`define-opts` macro previously. You can supply `prefix` and `suffix`
-arguments that will be printed before and after options respectively. If
-`usage-of` is supplied, it should be a string, name of the program for
-"Usage: " section. This section is only printed if this name is given. If
-your program takes arguments (apart from options), you can specify how to
-print them in "Usage: " section with `args` option (should be a string
-designator). Output goes to `stream` (default value is `*standard-output*`).
-
 ## Example
 
-Go to `example` directory. Now, you can use `example.lisp` file to see if
+Go to the `example` directory. Now, you can use `example.lisp` file to see if
 `unix-opts` is cool enough for you to use. SBCL users can use `example.sh`
-file. Here is some tests:
+file.
 
-```
-$ sh example.sh --help
-example—program to demonstrate unix-opts library
-
-Usage: example.sh [-h|--help] [-v|--verbose] [-l|--level LEVEL]
-                  [-o|--output FILE] [FREE-ARGS]
-
-Available options:
-  -h, --help               print this help text
-  -v, --verbose            verbose output
-  -l, --level LEVEL        the program will run on LEVEL level
-  -o, --output FILE        redirect output to file FILE
-
-so that's how it works…
-free args:
-$ sh example.sh -v file1.txt file2.txt
-OK, running in verbose mode…
-free args: file1.txt, file2.txt
-$ sh example.sh --level 10 --output foo.txt bar.txt
-I see you've supplied level option, you want 10 level!
-I see you want to output the stuff to "foo.txt"!
-free args: bar.txt
-$ sh example.sh --level kitty foo.txt
-fatal: cannot parse "kitty" as argument of "--level"
-free args:
-$ sh example.sh --hoola-boola noola.txt
-warning: "--hoola-boola" option is unknown!
-free args: noola.txt
-$ sh example.sh -vgl=10
-warning: "-g" option is unknown!
-OK, running in verbose mode…
-I see you've supplied level option, you want 10 level!
-free args:
-```
 
 Take a look at `example.lisp` and you will see that the library is pretty
 sexy! Basically, we have defined all the options just like this:
@@ -200,14 +164,8 @@ sexy! Basically, we have defined all the options just like this:
    :meta-var "FILE"))
 ```
 
-and we read them like so:
-
-```
-(opts:get-opts)
-```
-
-which returns two values, a list of parsed options and the remaining
-arguments:
+and we read them with `(opts:get-opts)` which returns two values, a
+list of parsed options and the remaining arguments, so:
 
 ```
 (multiple-value-bind (options free-args)
@@ -218,6 +176,47 @@ arguments:
 
 See the example for helpers and how to handle malformed or incomplete arguments.
 
+Here is an example usage:
+
+```
+$ sh example.sh --help
+example—program to demonstrate unix-opts library
+
+Usage: example.sh [-h|--help] [-v|--verbose] [-l|--level LEVEL]
+                  [-o|--output FILE] [FREE-ARGS]
+
+Available options:
+  -h, --help               print this help text
+  -v, --verbose            verbose output
+  -l, --level LEVEL        the program will run on LEVEL level
+  -o, --output FILE        redirect output to file FILE
+
+so that's how it works…
+free args:
+
+$ sh example.sh -v file1.txt file2.txt
+OK, running in verbose mode…
+free args: file1.txt, file2.txt
+
+$ sh example.sh --level 10 --output foo.txt bar.txt
+I see you've supplied level option, you want 10 level!
+I see you want to output the stuff to "foo.txt"!
+free args: bar.txt
+
+$ sh example.sh --level kitty foo.txt
+fatal: cannot parse "kitty" as argument of "--level"
+free args:
+
+$ sh example.sh --hoola-boola noola.txt
+warning: "--hoola-boola" option is unknown!
+free args: noola.txt
+
+$ sh example.sh -vgl=10
+warning: "-g" option is unknown!
+OK, running in verbose mode…
+I see you've supplied level option, you want 10 level!
+free args:
+```
 ## License
 
 Copyright © 2015–2017 Mark Karpov

--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ your program takes arguments (apart from options), you can specify how to
 print them in "Usage: " section with an `args` option (should be a string
 designator). Output goes to `stream` (default value is `*standard-output*`).
 
+### `(exit &optional (status 0))`
+
+Portable way to exit and return `status` (0 by default).
+
+
 Handling malformed options
 --------------------------
 
@@ -170,8 +175,11 @@ list of parsed options and the remaining arguments, so:
 ```
 (multiple-value-bind (options free-args)
     (opts:get-opts)
-  (if (getf options :verbose)
-      ...
+  (if (getf options :help)
+      (progn
+        (describe)
+        (exit)))
+   ...
 ```
 
 See the example for helpers and how to handle malformed or incomplete arguments.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ behavior of the parser via Common Lisp restarts.
 
 Inspired by Haskell's `optparse-applicative` and Python's `argparse`.
 
+It is portable accross many implementations (10 and counting).
+
 ## Installation
 
 Copy files of this library in any place where ASDF can find them. Then you
@@ -23,6 +25,9 @@ Via Quicklisp (recommended):
 ```common-lisp
 (ql:quickload "unix-opts")
 ```
+
+Now you can use its shorter nickname `opts`.
+
 
 ## Description
 
@@ -194,6 +199,24 @@ sexy! Basically, we have defined all the options just like this:
    :arg-parser #'identity
    :meta-var "FILE"))
 ```
+
+and we read them like so:
+
+```
+(opts:get-opts)
+```
+
+which returns two values, a list of parsed options and the remaining
+arguments:
+
+```
+(multiple-value-bind (options free-args)
+    (opts:get-opts)
+  (if (getf options :verbose)
+      ...
+```
+
+See the example for helpers and how to handle malformed or incomplete arguments.
 
 ## License
 

--- a/unix-opts.lisp
+++ b/unix-opts.lisp
@@ -418,3 +418,15 @@ goes to STREAM."
       (format stream "Available options:~%")
       (print-opts stream))
     (print-part suffix)))
+
+(defun exit (&optional (status 0))
+  "Exit from Lisp. Return `status' (0 by default)."
+  ;; thanks CLON.
+  #+sbcl      (sb-ext:exit :code status)
+  #+cmu       (unix:unix-exit status)
+  #+ccl       (ccl:quit status)
+  #+ecl       (ext:quit status)
+  #+clisp     (ext:exit status)
+  #+abcl      (extensions:exit :status status)
+  #+allegro   (excl:exit status :quiet t)
+  #+lispworks (lispworks:quit :status status))


### PR DESCRIPTION
a portable way to exit and return a status. Slightly adapted from CLON.

(sorry for the doc commits from the other PR, they were in master…)