### PR TITLE
Fix `argv` function on CCL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unix-opts 0.1.7
+* Fix the `argv` function on clozure
+
 ## Unix-opts 0.1.6
 
 * Actually exported the `exit` function from the `unix-opts` package.

--- a/tests.lisp
+++ b/tests.lisp
@@ -110,6 +110,8 @@ recommended to supply them all if you don't want to end in the debugger."
 (defun run-tests ()
   "Run Unix-opts tests. Signal failure if any test fails and return NIL
 otherwise."
+  (assert (typep (argv) 'list))
+
   (multiple-value-bind (options free-args)
       (parse-opts '("--grab-int" "10" "--rere" "11" "-s" "-a" "foo.txt")
                   :unknown-option    '(skip-option)

--- a/unix-opts-tests.asd
+++ b/unix-opts-tests.asd
@@ -24,7 +24,7 @@
 ;;; WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 (asdf:defsystem :unix-opts-tests
-  :version      "0.1.6"
+  :version      "0.1.7"
   :description  "tests for unix-opts-tests"
   :author       "Mark Karpov"
   :license      "MIT"

--- a/unix-opts.asd
+++ b/unix-opts.asd
@@ -25,7 +25,7 @@
 ;;; WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 (asdf:defsystem :unix-opts
-  :version      "0.1.6"
+  :version      "0.1.7"
   :description  "minimalistic parser of command line arguments"
   :author       "Mark Karpov"
   :license      "MIT"

--- a/unix-opts.lisp
+++ b/unix-opts.lisp
@@ -194,7 +194,7 @@ the program as first elements of the list. Portable across implementations."
   #+allegro   sys:command-line-arguments
   #+:ccl      ccl:*command-line-argument-list*
   #+clisp     (cons *load-truename* ext:*args*)
-  #+clozure   ccl::command-line-arguments
+  #+clozure   ccl:*command-line-argument-list*
   #+cmu       extensions:*command-line-words*
   #+ecl       (ext:command-args)
   #+gcl       si:*command-args*


### PR DESCRIPTION
Also make sure the `ARGV` function is tested during unit tests.

This closes #9.