### PR TITLE
Fix a bug: unknown-option

### DIFF
--- a/unix-opts.lisp
+++ b/unix-opts.lisp
@@ -254,10 +254,13 @@ the program as first elements of the list. Portable across implementations."
              (let ((x (string x)))
                (when (>= (length x) (length opt))
                  (string= x opt :end1 (length opt))))))
-      (let ((matches (remove-if-not #'prefix-p *options* :key key)))
-        (if (cadr matches)
-            nil
-            (car matches))))))
+      (let* ((matches (remove-if-not #'prefix-p *options* :key key))
+             (exact-match (find-if #'(lambda (x) (string= x opt))
+                                   matches :key key)))
+        (cond
+          (exact-match exact-match)
+          ((cadr matches) nil)
+          (otherwise (car matches)))))))
 
 (defun get-opts (&optional options)
   "Parse command line options. If OPTIONS is given, it should be a list to

--- a/unix-opts.lisp
+++ b/unix-opts.lisp
@@ -260,7 +260,7 @@ the program as first elements of the list. Portable across implementations."
         (cond
           (exact-match exact-match)
           ((cadr matches) nil)
-          (otherwise (car matches)))))))
+          (t (car matches)))))))
 
 (defun get-opts (&optional options)
   "Parse command line options. If OPTIONS is given, it should be a list to


### PR DESCRIPTION
Fix a bug: the parser signals unknown-option for --option when there is another longer option of the form --option-long.