### PR TITLE
Fix command line argument retrieval for Allegro CL

### DIFF
--- a/unix-opts.lisp
+++ b/unix-opts.lisp
@@ -191,7 +191,7 @@ printed in option description."
   "Return a list of program's arguments, including command used to execute
 the program as first elements of the list. Portable across implementations."
   #+abcl      ext:*command-line-argument-list*
-  #+allegro   sys:command-line-arguments
+  #+allegro   (sys:command-line-arguments)
   #+:ccl      ccl:*command-line-argument-list*
   #+clisp     (cons *load-truename* ext:*args*)
   #+clozure   ccl:*command-line-argument-list*


### PR DESCRIPTION
In Allegro CL, the symbol `sys:command-line-arguments' is a function
and must be called in order to correctly access command line arguments.