### PR TITLE
only pad opt descriptions to a max of argument-block-width

### DIFF
--- a/tests.lisp
+++ b/tests.lisp
@@ -293,11 +293,26 @@ recommended to supply them all if you don't want to end in the debugger."
     (assert (equal described (format nil "~
 Available options:
   -i, --grab-int INT (Required)
-                                grab integer INT
-  -s, --grab-str STR            grab string STR
-  -a                            flag with short form only
-  --flag-b                      flag with long form only
-  --flag-c ARG                  flag with default value [Default: (1 2)]
+                            grab integer INT
+  -s, --grab-str STR        grab string STR
+  -a                        flag with short form only
+  --flag-b                  flag with long form only
+  --flag-c ARG              flag with default value [Default: (1 2)]
+
+"))))
+
+  (let ((described (with-output-to-string (s)
+                     (describe :stream s :argument-block-width 10))))
+    (assert (equal described (format nil "~
+Available options:
+  -i, --grab-int INT (Required)
+             grab integer INT
+  -s, --grab-str STR
+             grab string STR
+  -a         flag with short form only
+  --flag-b   flag with long form only
+  --flag-c ARG
+             flag with default value [Default: (1 2)]
 
 "))))
 
@@ -305,11 +320,11 @@ Available options:
                      (describe :stream s :argument-block-width 30))))
     (assert (equal described (format nil "~
 Available options:
-  -i, --grab-int INT (Required) grab integer INT
-  -s, --grab-str STR            grab string STR
-  -a                            flag with short form only
-  --flag-b                      flag with long form only
-  --flag-c ARG                  flag with default value [Default: (1 2)]
+  -i, --grab-int INT (Required)  grab integer INT
+  -s, --grab-str STR             grab string STR
+  -a                             flag with short form only
+  --flag-b                       flag with long form only
+  --flag-c ARG                   flag with default value [Default: (1 2)]
 
 "))))
 
@@ -319,11 +334,11 @@ Available options:
                                :argument-block-width 30))))
     (assert (equal described (format nil "~
 Options:
-  -i, --grab-int INT (Required) grab integer INT
-  -s, --grab-str STR            grab string STR
-  -a                            flag with short form only
-  --flag-b                      flag with long form only
-  --flag-c ARG                  flag with default value [Default: (1 2)]
+  -i, --grab-int INT (Required)  grab integer INT
+  -s, --grab-str STR             grab string STR
+  -a                             flag with short form only
+  --flag-b                       flag with long form only
+  --flag-c ARG                   flag with default value [Default: (1 2)]
 
 "))))
 
@@ -337,11 +352,11 @@ program usage: foo [-i|--grab-int INT (Required)] [-s|--grab-str STR] [-a]
                    [--flag-b] [--flag-c ARG]
 
 Available options:
-  -i, --grab-int INT (Required) grab integer INT
-  -s, --grab-str STR            grab string STR
-  -a                            flag with short form only
-  --flag-b                      flag with long form only
-  --flag-c ARG                  flag with default value [Default: (1 2)]
+  -i, --grab-int INT (Required)  grab integer INT
+  -s, --grab-str STR             grab string STR
+  -a                             flag with short form only
+  --flag-b                       flag with long form only
+  --flag-c ARG                   flag with default value [Default: (1 2)]
 
 ")))))
 

--- a/unix-opts.lisp
+++ b/unix-opts.lisp
@@ -487,7 +487,7 @@ text is wider than ARGUMENT-BLOCK-WIDTH."
            (concatenate 'string
                         string
                         (make-string (- max-size
-                                         (length string))
+                                        (length string))
                                      :initial-element #\Space))))
     (let* ((option-strings (mapcar
                             (lambda (opt)
@@ -508,20 +508,16 @@ text is wider than ARGUMENT-BLOCK-WIDTH."
                                              (format nil " [Default: ~A]" (maybe-funcall default))
                                              ""))))
                                   (cons opts-and-meta full-description))))
-                            defined-options))
-           (max-opts-length (reduce #'max
-                                    (mapcar (lambda (el)
-                                              (length (car el)))
-                                            option-strings)
-                                    :initial-value 0)))
+                            defined-options)))
       (loop
         :for (opt-meta . opt-description) :in option-strings
         :for newline = (>= (length opt-meta)
                            argument-block-width)
         :do (format stream "  ~a~a~%"
-                    (pad-right opt-meta (+ (if newline 0 1) max-opts-length))
+                    (pad-right opt-meta (max (+ (if newline 0 1) argument-block-width)
+                                             (length opt-meta)))
                     (add-text-padding opt-description
-                                      :padding (+ 3 max-opts-length)
+                                      :padding (+ 3 argument-block-width)
                                       :newline newline)))
       (terpri stream))))
 


### PR DESCRIPTION
This might be me misunderstanding the intent, but when adding a newline after a long option name, it's indented like this:

```
  -p, --path SOME_LONG_TEXT_HERE
                                 This is the path to do something to.
  -n, --name NAME                Your name.
```
which doesn't seem like the newline is helping anything since the line's the same length as if it was just:
```
  -p, --path SOME_LONG_TEXT_HERE This is the path to do something to.
  -n, --name NAME                Your name.
```

This patch makes it left-pad the descriptions to a maximum of `argument-block-width` which I personally think makes a lot more sense, as that's the point when they're put on the next line.

So instead for a block width of 25 it would look like:
```
  -p, --path SOME_LONG_TEXT_HERE
                         This is the path to do something to.
  -n, --name NAME        Your name.
```

Let me know what you think.  I'll wait to see what you think before updating the tests.