### PR TITLE
add "brief" keyword arg for showing only the usage

### DIFF
--- a/unix-opts.lisp
+++ b/unix-opts.lisp
@@ -553,7 +553,8 @@ it gets too long. MARGIN specifies margin."
             (princ str s)))))))
 
 (defun describe (&key prefix suffix usage-of args (stream *standard-output*) (argument-block-width 25)
-                   (defined-options *options*) (usage-of-label "Usage") (available-options-label "Available options"))
+                   (defined-options *options*) (usage-of-label "Usage") (available-options-label "Available options")
+                   brief)
   "Return string describing options of the program that were defined with
 `define-opts' macro previously. You can supply PREFIX and SUFFIX arguments
 that will be printed before and after options respectively. If USAGE-OF is
@@ -591,7 +592,7 @@ The output goes to STREAM."
                               2) ; colon and space
                            defined-options)
               args))
-    (when defined-options
+    (when (and (or (not usage-of) (not brief)) defined-options)
       (format stream "~a:~%" available-options-label)
       (print-opts defined-options stream argument-block-width))
     (print-part suffix)))

--- a/unix-opts.lisp
+++ b/unix-opts.lisp
@@ -576,6 +576,9 @@ argument `available-options-label'
 (default value: \"Available options\")
 on a single line
 
+If USAGE-OF is provided and BRIEF is non-NIL, the 'available options'
+block will be omitted from the output.
+
 The output goes to STREAM."
   (flet ((print-part (str)
            (when str
@@ -592,7 +595,7 @@ The output goes to STREAM."
                               2) ; colon and space
                            defined-options)
               args))
-    (when (and (or (not usage-of) (not brief)) defined-options)
+    (when (and (not (and usage-of brief)) defined-options)
       (format stream "~a:~%" available-options-label)
       (print-opts defined-options stream argument-block-width))
     (print-part suffix)))


### PR DESCRIPTION
Another feature request/implementation: Sometimes when there are a lot of command line arguments, you just want to show the "Usage: " line as opposed to printing all the options with their descriptions which can take up multiple screens if there are a lot (e.g. if the program is ran with no flags but some are required, you might just want to print the "usage" part of the description).  This is a small change that adds a `brief` keyword argument that will cause the option+description rows to be omitted as long as `usage-of` is also passed.