### PR TITLE
fix print-opts* wrapping

### DIFF
--- a/tests.lisp
+++ b/tests.lisp
@@ -234,9 +234,9 @@ recommended to supply them all if you don't want to end in the debugger."
                   :missing-arg       '(use-value "my-string")
                   :arg-parser-failed '(reparse-arg "15"))
     (assert (equalp options '(:grab-int 15
-                          :grab-str "my-string"
-                          :grab-int "my-string"
-                          :flag-c (1 2))))
+                              :grab-str "my-string"
+                              :grab-int "my-string"
+                              :flag-c (1 2))))
     (assert (equalp free-args nil))
     (assert (equalp *unknown-options* '("--foobar" "-l")))
     (assert (equalp *missing-arg-options* '("-s" "--grab-int")))
@@ -430,6 +430,61 @@ Available options:
                              (invoke-restart 'skip-option))))
         (equalp (parse-opts '("--op" "5") :all-options options) '(:opt-longer 5)))
       (assert signaled))))
+
+(test wrapping-usage-line
+  :description "Usage line should wrap when the next option would put it past MAX-WIDTH characters"
+  (let ((described (with-output-to-string (s)
+                     (describe :stream    s
+                               :usage-of  "foo"
+                               :max-width 50))))
+    (assert (equal described (format nil "
+Usage: foo [-i|--grab-int INT (Required)]
+           [-s|--grab-str STR] [-a] [--flag-b]
+           [--flag-c ARG]
+
+Available options:
+  -i, --grab-int INT (Required)
+                                grab integer INT
+  -s, --grab-str STR            grab string STR
+  -a                            flag with short form only
+  --flag-b                      flag with long form only
+  --flag-c ARG                  flag with default value [Default: (1 2)]
+
+"))))
+
+  (let ((described (with-output-to-string (s)
+                     (describe :stream    s
+                               :usage-of  "foo"))))
+    (assert (equal described (format nil "
+Usage: foo [-i|--grab-int INT (Required)] [-s|--grab-str STR] [-a] [--flag-b]
+           [--flag-c ARG]
+
+Available options:
+  -i, --grab-int INT (Required)
+                                grab integer INT
+  -s, --grab-str STR            grab string STR
+  -a                            flag with short form only
+  --flag-b                      flag with long form only
+  --flag-c ARG                  flag with default value [Default: (1 2)]
+
+"))))
+
+  (let ((described (with-output-to-string (s)
+                     (describe :stream    s
+                               :usage-of  "foo"
+                               :max-width 100))))
+    (assert (equal described (format nil "
+Usage: foo [-i|--grab-int INT (Required)] [-s|--grab-str STR] [-a] [--flag-b] [--flag-c ARG]
+
+Available options:
+  -i, --grab-int INT (Required)
+                                grab integer INT
+  -s, --grab-str STR            grab string STR
+  -a                            flag with short form only
+  --flag-b                      flag with long form only
+  --flag-c ARG                  flag with default value [Default: (1 2)]
+
+")))))
 
 (defun run ()
   (let ((success t))

--- a/unix-opts.lisp
+++ b/unix-opts.lisp
@@ -525,11 +525,11 @@ text is wider than ARGUMENT-BLOCK-WIDTH."
                                       :newline newline)))
       (terpri stream))))
 
-(defun print-opts* (margin defined-options)
+(defun print-opts* (margin max-width defined-options)
   "Return a string containing info about defined options. All options are
 displayed on one line, although this function tries to print it elegantly if
 it gets too long. MARGIN specifies margin."
-  (let ((fill-col (- 80 margin))
+  (let ((fill-col (- max-width margin))
         (i 0)
         (last-newline 0))
     (with-output-to-string (s)
@@ -554,7 +554,8 @@ it gets too long. MARGIN specifies margin."
             (princ str s)))))))
 
 (defun describe (&key prefix suffix usage-of args (stream *standard-output*) (argument-block-width 25)
-                   (defined-options *options*) (usage-of-label "Usage") (available-options-label "Available options"))
+                   (defined-options *options*) (usage-of-label "Usage") (available-options-label "Available options")
+                   (max-width 80))
   "Return string describing options of the program that were defined with
 `define-opts' macro previously. You can supply PREFIX and SUFFIX arguments
 that will be printed before and after options respectively. If USAGE-OF is
@@ -590,6 +591,7 @@ The output goes to STREAM."
               (print-opts* (+ (length usage-of-label)
                               (length usage-of)
                               2) ; colon and space
+                           max-width
                            defined-options)
               args))
     (when defined-options

--- a/unix-opts.lisp
+++ b/unix-opts.lisp
@@ -535,21 +535,22 @@ it gets too long. MARGIN specifies margin."
     (with-output-to-string (s)
       (dolist (opt defined-options)
         (with-slots (short long required arg-parser meta-var) opt
-          (let ((str
-                  (format nil " [~a]"
-                          (concatenate
-                           'string
-                           (if short (format nil "-~c" short) "")
-                           (if (and short long) "|" "")
-                           (if long  (format nil "--~a" long) "")
-                           (if arg-parser (format nil " ~a" meta-var) "")
-                           (if required (format nil " (Required)") "")))))
-            (incf i (length str))
-            (when (> (- i last-newline) fill-col)
+          (let* ((str
+                   (format nil " [~a]"
+                           (concatenate
+                            'string
+                            (if short (format nil "-~c" short) "")
+                            (if (and short long) "|" "")
+                            (if long  (format nil "--~a" long) "")
+                            (if arg-parser (format nil " ~a" meta-var) "")
+                            (if required (format nil " (Required)") ""))))
+                 (length (length str)))
+            (when (> (- (+ i length) last-newline) fill-col)
               (terpri s)
               (dotimes (x margin)
                 (princ #\space s))
               (setf last-newline i))
+            (incf i length)
             (princ str s)))))))
 
 (defun describe (&key prefix suffix usage-of args (stream *standard-output*) (argument-block-width 25)


### PR DESCRIPTION
A bug fix this time: `i` was incremented to add the length of the opt before `last-newline` was set, when `last-newline` should've been set to the index before the current opt since the newline is added to the string before the current opt is.