### PR TITLE
Allow usage on the first line of help output

### DIFF
--- a/example/example.lisp
+++ b/example/example.lisp
@@ -86,7 +86,7 @@
   ;; logic to process them.
   (when-option (options :help)
     (opts:describe
-     :prefix "example—program to demonstrate unix-opts library"
+     :prefix (format nil "example—program to demonstrate unix-opts library~%")
      :suffix "so that's how it works…"
      :usage-of "example.sh"
      :args     "[FREE-ARGS]"))

--- a/unix-opts.lisp
+++ b/unix-opts.lisp
@@ -552,12 +552,13 @@ it gets too long. MARGIN specifies margin."
               (setf last-newline i))
             (princ str s)))))))
 
-(defun describe (&key prefix suffix usage-of args (stream *standard-output*) (argument-block-width 25)
+(defun describe (&key prefix tagline suffix usage-of args (stream *standard-output*) (argument-block-width 25)
                    (defined-options *options*) (usage-of-label "Usage") (available-options-label "Available options")
                    brief)
   "Return string describing options of the program that were defined with
 `define-opts' macro previously. You can supply PREFIX and SUFFIX arguments
-that will be printed before and after options respectively. If USAGE-OF is
+that will be printed before and after options respectively. TAGLINE, when
+supplied, will be printed on the line after usage. If USAGE-OF is
 supplied, it should be a string, name of the program for \"Usage: \"
 section. This section is only printed if this name is given.
 
@@ -586,14 +587,15 @@ The output goes to STREAM."
              (terpri stream))))
     (print-part prefix)
     (when usage-of
-      (format stream "~a: ~a~a~@[ ~a~]~%~%"
+      (format stream "~a: ~a~a~@[ ~a~]~%~@[~a~]~%"
               usage-of-label
               usage-of
               (print-opts* (+ (length usage-of-label)
                               (length usage-of)
                               2) ; colon and space
                            defined-options)
-              args))
+              args
+              tagline))
     (when (and (not (and usage-of brief)) defined-options)
       (format stream "~a:~%" available-options-label)
       (print-opts defined-options stream argument-block-width))

--- a/unix-opts.lisp
+++ b/unix-opts.lisp
@@ -586,7 +586,6 @@ The output goes to STREAM."
              (terpri stream))))
     (print-part prefix)
     (when usage-of
-      (terpri stream)
       (format stream "~a: ~a~a~@[ ~a~]~%~%"
               usage-of-label
               usage-of


### PR DESCRIPTION
Hi libre-man,

Thanks for maintaining unix-opts.

I'd like usage to go on the first line of --help output, and also to be able to specify a brief description of the tool just after the usage line, like GNU grep and other tools do.

This pull request does those two things.

If the API user wants a blank line between the prefix and usage lines, they can pass (format nil "this prefix~%") instead of "this prefix".  I think that's better than hard-coding a terpri before the usage line, which doesn't give the option of putting usage on the first line.

Thanks,
fitzsim